### PR TITLE
Update RPM specfile, add curl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ test_runner
 statsite
 .vagrant
 *.pyc
+
+dist/
+rpm-build/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-RPMBUILDROOT=./rpm-build
+RPMBUILDROOT=$(shell pwd)/rpm-build
 
 build:
 	scons statsite

--- a/rpm/statsite.spec
+++ b/rpm/statsite.spec
@@ -1,20 +1,21 @@
 %global __os_install_post %(echo '%{__os_install_post}' | sed -e 's!/usr/lib[^[:space:]]*/brp-python-bytecompile[[:space:]].*$!!g')
 
 Name:		statsite
-Version:	0.7.0
+Version:	0.7.0-t1
 Release:	1%{?dist}
 Summary:	A C implementation of statsd.
 Group:		Applications
 License:	See the LICENSE file.
-URL:		https://github.com/armon/statsite
+URL:		https://github.com/twitter-forks/statsite
 Source0:	statsite.tar.gz
+Requires:       %{!?el5:libcurl} %{?el5:curl}
 BuildRoot:	%(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
-BuildRequires:	scons
+BuildRequires:	scons gcc check-devel %{?el5:curl-devel} %{!?el5:libcurl-devel}
 AutoReqProv:	No
 
 %description
 
-Statsite is a metrics aggregation server. Statsite is based heavily on Etsy's StatsD
+Statsite is a metrics aggregation server. Statsite is based heavily on Etsy\'s StatsD
 https://github.com/etsy/statsd, and is wire compatible.
 
 %prep

--- a/rpm/statsite.spec
+++ b/rpm/statsite.spec
@@ -1,8 +1,8 @@
 %global __os_install_post %(echo '%{__os_install_post}' | sed -e 's!/usr/lib[^[:space:]]*/brp-python-bytecompile[[:space:]].*$!!g')
 
 Name:		statsite
-Version:	0.7.0-t1
-Release:	1%{?dist}
+Version:	0.7.0.t1
+Release:	2%{?dist}
 Summary:	A C implementation of statsd.
 Group:		Applications
 License:	See the LICENSE file.
@@ -53,9 +53,9 @@ exit 0
 
 %preun
 if [ "$1" = 0 ] ; then
-	%if %{monit_bin}
+%if "%{monit_bin}"
 	%{monit_bin} stop %{name}
-	%endif
+%endif
 	/sbin/service %{name} stop > /dev/null 2>&1
 	/sbin/chkconfig --del %{name}
 fi
@@ -79,8 +79,13 @@ exit 0
 %attr(755, root, root) /usr/libexec/statsite/sinks/gmetric.py
 %attr(755, root, root) /usr/libexec/statsite/sinks/influxdb.py
 %attr(755, root, root) /usr/libexec/statsite/sinks/graphite.py
+%attr(755, root, root) /usr/libexec/statsite/sinks/cloudwatch.sh
+%attr(755, root, root) /usr/libexec/statsite/sinks/opentsdb.js
 
 %changelog
+* Mon May 11 2015 Yann Ramin <yann@twitter.com> - 0.7.0.t1-2
+- Introduce libcurl and cleanup spec file builds for tXX versions
+
 * Fri Jul 18 2014 Gary Richardson <gary.richardson@gmail.com>
 - added missing __init__.py to spec file
 - fixed makefile for building RPMS


### PR DESCRIPTION
Add a curl dependency in builds, and solve any RPM regressions which have cropped up.

This also bumps to "t1" as the version suffix (good? bad? we need something internal)
