### PR TITLE
Add jansson as a system dependency.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,14 +12,14 @@ addons:
       - scons
       - check
       - python
-      - libjansson-devel
+      - libjansson-dev
 
 python:
   - "2.7"
 
 before_install:
   - sudo apt-get update -qq
-  - sudo apt-get install -y check scons python-virtualenv libjansson-devel
+  - sudo apt-get install -y check scons python-virtualenv libjansson-dev
   - sudo apt-get autoremove
   - scons statsite test_runner
   - virtualenv ve

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,13 +12,14 @@ addons:
       - scons
       - check
       - python
+      - libjansson-devel
 
 python:
   - "2.7"
 
 before_install:
   - sudo apt-get update -qq
-  - sudo apt-get install -y check scons python-virtualenv
+  - sudo apt-get install -y check scons python-virtualenv libjansson-devel
   - sudo apt-get autoremove
   - scons statsite test_runner
   - virtualenv ve

--- a/rpm/statsite.spec
+++ b/rpm/statsite.spec
@@ -8,9 +8,9 @@ Group:		Applications
 License:	See the LICENSE file.
 URL:		https://github.com/twitter-forks/statsite
 Source0:	statsite.tar.gz
-Requires:       %{!?el5:libcurl} %{?el5:curl}
+Requires:       %{!?el5:libcurl} %{?el5:curl} jansson
 BuildRoot:	%(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
-BuildRequires:	scons gcc check-devel %{?el5:curl-devel} %{!?el5:libcurl-devel}
+BuildRequires:	scons gcc check-devel %{?el5:curl-devel} %{!?el5:libcurl-devel} jansson-devel
 AutoReqProv:	No
 
 %description


### PR DESCRIPTION
Confirmed to exist on:
- Ubunu (for Travis)
- EPEL 6
- Fedora (due to EPEL)

However, its not in EPEL 5. Probably not much of a loss.
