### PR TITLE
HTTP+JSON serialization sink

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ addons:
       - check
       - python
       - libjansson-dev
+      - libcurl3-openssl-dev
 
 python:
   - "2.7"
@@ -20,7 +21,7 @@ python:
 before_install:
   - whereis clang
   - sudo apt-get update -qq
-  - sudo apt-get install -y check scons python-virtualenv libjansson-dev clang
+  - sudo apt-get install -y check scons python-virtualenv libjansson-dev libcurl4-openssl-dev clang
   - sudo apt-get autoremove
   - whereis clang
   - scons statsite test_runner

--- a/SConstruct
+++ b/SConstruct
@@ -39,6 +39,7 @@ env_statsite_libev = ENV.Clone(CFLAGS = " ".join(CFLAGS_LIBEV))
 
 objs = env_statsite_with_err.Object('src/hashmap', 'src/hashmap.c')           + \
         env_statsite_with_err.Object('src/heap', 'src/heap.c')                + \
+        env_statsite_with_err.Object('src/strbuf', 'src/strbuf.c')            + \
         env_statsite_with_err.Object('src/radix', 'src/radix.c')              + \
         env_statsite_with_err.Object('src/hll_constants', 'src/hll_constants.c') + \
         env_statsite_with_err.Object('src/hll', 'src/hll.c')                  + \

--- a/SConstruct
+++ b/SConstruct
@@ -58,7 +58,7 @@ objs = env_statsite_with_err.Object('src/hashmap', 'src/hashmap.c')           + 
         env_statsite_libev.Object('src/networking', 'src/networking.c')       + \
         env_statsite_libev.Object('src/conn_handler', 'src/conn_handler.c')
 
-statsite_libs = ["m", "pthread", murmur, inih, "jansson"]
+statsite_libs = ["m", "pthread", murmur, inih, "jansson", "curl"]
 if platform.system() == 'Linux':
    statsite_libs.append("rt")
 

--- a/SConstruct
+++ b/SConstruct
@@ -53,10 +53,11 @@ objs = env_statsite_with_err.Object('src/hashmap', 'src/hashmap.c')           + 
         env_statsite_with_err.Object('src/sink', 'src/sink.c')                + \
         env_statsite_with_err.Object('src/sink_stream', 'src/sink_stream.c')  + \
         env_statsite_with_err.Object('src/lifoq', 'src/lifoq.c')              + \
+        env_statsite_with_err.Object('src/sink_http', 'src/sink_http.c')      + \
         env_statsite_libev.Object('src/networking', 'src/networking.c')       + \
         env_statsite_libev.Object('src/conn_handler', 'src/conn_handler.c')
 
-statsite_libs = ["m", "pthread", murmur, inih]
+statsite_libs = ["m", "pthread", murmur, inih, "jansson"]
 if platform.system() == 'Linux':
    statsite_libs.append("rt")
 

--- a/SConstruct
+++ b/SConstruct
@@ -8,6 +8,11 @@ ENV["CXX"] = os.getenv("CXX") or ENV["CXX"]
 ENV["PATH"] = os.getenv("PATH") or ENV["PATH"]
 ENV["ENV"].update(x for x in os.environ.items() if x[0].startswith("CCC_"))
 
+if "CURL_LIB" in os.environ:
+  curl_lib = os.environ["CURL_LIB"]
+else:
+  curl_lib = "curl"
+
 CFLAGS = ["-Wall",
           "-Wno-unused-function",
           "-std=c99",
@@ -58,7 +63,7 @@ objs = env_statsite_with_err.Object('src/hashmap', 'src/hashmap.c')           + 
         env_statsite_libev.Object('src/networking', 'src/networking.c')       + \
         env_statsite_libev.Object('src/conn_handler', 'src/conn_handler.c')
 
-statsite_libs = ["m", "pthread", murmur, inih, "jansson", "curl"]
+statsite_libs = ["m", "pthread", murmur, inih, "jansson", curl_lib]
 if platform.system() == 'Linux':
    statsite_libs.append("rt")
 

--- a/rpm/statsite.initscript
+++ b/rpm/statsite.initscript
@@ -71,7 +71,6 @@ case "$1" in
         RETVAL=$?
         ;;
     restart)
-        configtest -q || exit $RETVAL
         stop
         start
         ;;

--- a/src/config.c
+++ b/src/config.c
@@ -85,7 +85,8 @@ static const sink_config_http DEFAULT_HTTP_SINK = {
     .params = NULL,
     .metrics_name = "metrics",
     .timestamp_name = "timestamp",
-    .timestamp_format = "%s" /* Seconds since epoch */
+    .timestamp_format = "%s", /* Seconds since epoch */
+    .ciphers = NULL
 };
 
 /**
@@ -304,6 +305,8 @@ static int sink_callback(void* user, const char* section, const char* name, cons
             config->timestamp_name = strdup(value);
         } else if (NAME_MATCH("timestamp_format")) {
             config->timestamp_format = strdup(value);
+        } else if (NAME_MATCH("ciphers")) {
+            config->ciphers = strdup(value);
         } else {
             /* Attempt to locate keys
              * of the form param_PNAME */

--- a/src/config.c
+++ b/src/config.c
@@ -76,6 +76,18 @@ static const sink_config_stream DEFAULT_SINK = {
     .stream_cmd = "cat"
 };
 
+static const sink_config_http DEFAULT_HTTP_SINK = {
+    .super = { .type = SINK_TYPE_HTTP,
+               .name = "default",
+               .next = NULL
+    },
+    .post_url = NULL,
+    .params = NULL,
+    .metrics_name = "metrics",
+    .timestamp_name = "timestamp",
+    .timestamp_format = "%s" /* Seconds since epoch */
+};
+
 /**
  * Attempts to convert a string to a boolean,
  * and write the value out.
@@ -253,9 +265,10 @@ static int sink_callback(void* user, const char* section, const char* name, cons
             config->super.name = strdup(name);
             config->stream_cmd = DEFAULT_SINK.stream_cmd;
         } else if (strcasecmp(type, "http") == 0) {
-            sink_config_http* config = calloc(1, sizeof(sink_config_http));
+            sink_config_http* config = malloc(sizeof(sink_config_http));
+
+            memcpy(config, &DEFAULT_HTTP_SINK, sizeof(sink_config_http));
             sink_in_progress = (sink_config*)config;
-            config->super.type = SINK_TYPE_HTTP;
             config->super.name = strdup(name);
         } else {
             free(section_to_tokenize);
@@ -285,6 +298,12 @@ static int sink_callback(void* user, const char* section, const char* name, cons
         sink_config_http* config = (sink_config_http*)sink_in_progress;
         if (NAME_MATCH("url")) {
             config->post_url = strdup(value);
+        } else if (NAME_MATCH("metrics_name")) {
+            config->metrics_name = strdup(value);
+        } else if (NAME_MATCH("timestamp_name")) {
+            config->timestamp_name = strdup(value);
+        } else if (NAME_MATCH("timestamp_format")) {
+            config->timestamp_format = strdup(value);
         } else {
             /* Attempt to locate keys
              * of the form param_PNAME */
@@ -782,4 +801,3 @@ ERR:
     free(t);
     return 1;
 }
-

--- a/src/config.h
+++ b/src/config.h
@@ -61,6 +61,9 @@ typedef struct sink_config_http {
     sink_config super;
     const char* post_url;
     kv_config* params;
+    const char* metrics_name; /* The name of the metric parameter */
+    const char* timestamp_name; /* The name of the timestamp */
+    const char* timestamp_format; /* The format specifier, strftime format */
 } sink_config_http;
 
 // Represents the configuration of a histogram

--- a/src/config.h
+++ b/src/config.h
@@ -64,6 +64,7 @@ typedef struct sink_config_http {
     const char* metrics_name; /* The name of the metric parameter */
     const char* timestamp_name; /* The name of the timestamp */
     const char* timestamp_format; /* The format specifier, strftime format */
+    const char* ciphers; /* A platform dependent list of ciphers */
 } sink_config_http;
 
 // Represents the configuration of a histogram

--- a/src/conn_handler.c
+++ b/src/conn_handler.c
@@ -138,6 +138,11 @@ void final_flush(sink* sinks) {
     ops->sinks = sinks;
 
     flush_thread(ops);
+
+    for (sink* sink = sinks; sink != NULL; sink = sink->next) {
+        if (sink->close)
+            sink->close(sink);
+    }
 }
 
 

--- a/src/conn_handler.c
+++ b/src/conn_handler.c
@@ -78,7 +78,7 @@ static void* flush_thread(void *arg) {
             syslog(LOG_WARNING, "Streaming command %s exited with status %d", s->sink_config->name, res);
         }
     }
-    
+
     // Cleanup
     destroy_metrics(m);
     free(m);
@@ -127,11 +127,17 @@ void flush_interval_trigger(sink* sinks) {
  * Called when statsite is terminating to flush the
  * final set of metrics
  */
-void final_flush() {
+void final_flush(sink* sinks) {
     // Get the last set of metrics
     metrics *old = GLOBAL_METRICS;
     GLOBAL_METRICS = NULL;
-    flush_thread(old);
+
+    /* We heap allocate this in order to allow it to be freed by the function */
+    struct flush_op* ops = calloc(1, sizeof(struct flush_op));
+    ops->m = old;
+    ops->sinks = sinks;
+
+    flush_thread(ops);
 }
 
 

--- a/src/lifoq.h
+++ b/src/lifoq.h
@@ -11,7 +11,8 @@ enum {
     LIFOQ_INTERNAL_ERROR = -1,
     LIFOQ_INVALID_ENTRY = -2,
     LIFOQ_CLOSED = -3,
-    LIFOQ_ALREADY_CLOSED = -4
+    LIFOQ_ALREADY_CLOSED = -4,
+    LIFOQ_FULL = -5
 };
 
 /**
@@ -28,7 +29,7 @@ extern int lifoq_new(lifoq** q, size_t max_size);
  * If this function returns a non-zero error state, data will not be
  * free()ed.
  */
-extern int lifoq_push(lifoq* q, void* data, size_t size, bool should_free);
+extern int lifoq_push(lifoq* q, void* data, size_t size, bool should_free, bool fail_full);
 
 /**
  * Get an entry from the queue. Place the result in data, and return the

--- a/src/networking.c
+++ b/src/networking.c
@@ -251,8 +251,9 @@ static int setup_stdin_listener(statsite_networking *netconf) {
  * @arg config Takes the bloom server configuration
  * @arg mgr The filter manager to pass up to the connection handlers
  * @arg netconf Output. The configuration for the networking stack.
+ * @arg sinks The sinks to use for this network loop
  */
-int init_networking(statsite_config *config, statsite_networking **netconf_out) {
+int init_networking(statsite_config *config, statsite_networking **netconf_out, sink* sinks) {
     // Initialize the netconf structure
     statsite_networking *netconf = calloc(1, sizeof(struct statsite_networking));
     netconf->config = config;
@@ -299,7 +300,7 @@ int init_networking(statsite_config *config, statsite_networking **netconf_out) 
     }
 
     // Setup sinks
-    init_sinks(&netconf->sinks, config);
+    netconf->sinks = sinks;
 
     // Setup the timer
     ev_timer_init(&netconf->flush_timer, handle_flush_event, config->flush_interval, config->flush_interval);

--- a/src/networking.h
+++ b/src/networking.h
@@ -1,5 +1,6 @@
 #ifndef NETWORKING_H
 #define NETWORKING_H
+#include "sink.h"
 #include "config.h"
 
 // Network configuration struct
@@ -11,7 +12,7 @@ typedef struct conn_info statsite_conn_info;
  * @arg config Takes the statsite server configuration
  * @arg netconf Output. The configuration for the networking stack.
  */
-int init_networking(statsite_config *config, statsite_networking **netconf_out);
+int init_networking(statsite_config *config, statsite_networking **netconf_out, sink* sinks);
 
 /**
  * Entry point for main thread to enter the networking

--- a/src/sink.c
+++ b/src/sink.c
@@ -3,16 +3,26 @@
 
 /* Known sink constructors */
 extern sink* init_stream_sink(const sink_config_stream*, const statsite_config*);
+extern sink* init_http_sink(const sink_config_http*, const statsite_config*);
 
 int init_sinks(sink** sinks, statsite_config* config) {
     for(sink_config* sc = config->sink_configs; sc != NULL; sc = sc->next) {
-        if (sc->type == SINK_TYPE_STREAM) {
+        switch(sc->type) {
+        case SINK_TYPE_STREAM:
+        {
             sink* actual_sink = init_stream_sink((sink_config_stream*)sc, config);
-            if (*sinks) {
-                actual_sink->next = *sinks;
-            }
+            actual_sink->next = *sinks;
             *sinks = actual_sink;
-        } else {
+            break;
+        }
+        case SINK_TYPE_HTTP:
+        {
+            sink* actual_sink = init_http_sink((sink_config_http*)sc, config);
+            actual_sink->next = *sinks;
+            *sinks = actual_sink;
+            break;
+        }
+        default:
             syslog(LOG_NOTICE, "Unknown sink type %d - we should have never gotten here as the config mis-matches the runtime configuration options.", sc->type);
             return 1;
         }

--- a/src/sink.h
+++ b/src/sink.h
@@ -28,6 +28,12 @@ typedef struct sink {
      * Always pass this instance of sink to this function.
      */
     int (*command)(struct sink*, metrics* m, void* data);
+
+    /**
+     * A command to close this sink, allowing any flushing or cleanup
+     * actions appropiate for the sink.
+     */
+    void (*close)(struct sink*);
 } sink;
 
 /**

--- a/src/sink_http.c
+++ b/src/sink_http.c
@@ -249,7 +249,11 @@ static void* http_worker(void* arg) {
     char* error_buffer = malloc(CURL_ERROR_SIZE + 1);
     strbuf *recv_buf;
     strbuf_new(&recv_buf, 16384);
-    const char* ssl_ciphers = curl_which_ssl();
+    const char* ssl_ciphers;
+    if (httpconfig->ciphers)
+        ssl_ciphers = httpconfig->ciphers;
+    else
+        ssl_ciphers = curl_which_ssl();
 
     syslog(LOG_NOTICE, "Starting HTTP worker");
 

--- a/src/sink_http.c
+++ b/src/sink_http.c
@@ -1,0 +1,147 @@
+#include <stdio.h>
+#include <inttypes.h>
+#include <string.h>
+#include <jansson.h>
+
+#include "metrics.h"
+#include "sink.h"
+
+
+typedef struct http_sink {
+    sink sink;
+} http_sink;
+
+/*
+ * Data from the metrics_iter callback */
+struct cb_info {
+    json_t* jobject;
+    const statsite_config* config;
+    const sink_config_http *httpconfig;
+};
+
+/*
+ * TODO: There is a lot redundant code here with sink_stream to normalize
+ * an output representation of a metrics.
+ */
+static int add_metrics(void* data,
+                       metric_type type,
+                       char* name,
+                       void* value) {
+
+    struct cb_info* info = (struct cb_info*)data;
+    json_t* obj = info->jobject;
+    const statsite_config* config = info->config;
+
+    /*
+     * Scary looking macro to apply suffixes to a string, and then
+     * insert them into a json object with a given value. Needs "suffixed"
+     * in scope, with a "base_len" telling it how mmany chars the string is
+     */
+#define SUFFIX_ADD(suf, val)                                            \
+    do {                                                                \
+        suffixed[base_len - 1] = '\0';                                  \
+        strcat(suffixed, suf);                                          \
+        json_object_set_new(obj, suffixed, val);                        \
+    } while(0);
+
+    char* prefix = config->prefixes_final[type];
+    /* Using C99 stack allocation, don't panic */
+    int base_len = strlen(name) + strlen(prefix) + 1;
+    char full_name[base_len];
+    strcpy(full_name, prefix);
+    strcat(full_name, name);
+    switch (type) {
+    case KEY_VAL:
+        json_object_set_new(obj, full_name, json_real(*(double*)value));
+        break;
+    case GAUGE:
+        json_object_set_new(obj, full_name, json_real(*(double*)value));
+        break;
+    case COUNTER:
+    {
+        if (config->extended_counters) {
+            char suffixed[base_len + 8];
+            strcpy(suffixed, full_name);
+            SUFFIX_ADD(".count", json_integer(counter_count(value)));
+            SUFFIX_ADD(".mean", json_real(counter_mean(value)));
+            SUFFIX_ADD(".stdev", json_real(counter_stddev(value))); /* stdev matches other output */
+            SUFFIX_ADD(".sum", json_real(counter_sum(value)));
+            SUFFIX_ADD(".sum_sq", json_real(counter_squared_sum(value)));
+            SUFFIX_ADD(".lower", json_real(counter_min(value)));
+            SUFFIX_ADD(".upper", json_real(counter_max(value)));
+            SUFFIX_ADD(".rate", json_real(counter_sum(value) / config->flush_interval));
+        } else {
+            json_object_set_new(obj, full_name, json_real(counter_sum(value)));
+        }
+        break;
+    }
+    case SET:
+        json_object_set_new(obj, full_name, json_integer(set_size(value)));
+        break;
+    case TIMER:
+    {
+        timer_hist *t = (timer_hist*)value;
+        char suffixed[base_len + 20];
+        strcpy(suffixed, full_name);
+        SUFFIX_ADD(".sum", json_real(timer_sum(&t->tm)));
+        SUFFIX_ADD(".sum_sq", json_real(timer_squared_sum(&t->tm)));
+        SUFFIX_ADD(".mean", json_real(timer_mean(&t->tm)));
+        SUFFIX_ADD(".lower", json_real(timer_min(&t->tm)));
+        SUFFIX_ADD(".upper", json_real(timer_max(&t->tm)));
+        SUFFIX_ADD(".count", json_integer(timer_count(&t->tm)));
+        SUFFIX_ADD(".stdev", json_real(timer_stddev(&t->tm))); /* stdev matches other output */
+        for (int i = 0; i < config->num_quantiles; i++) {
+            char ptile[20];
+            sprintf(ptile, ".p%0.0f", config->quantiles[i] * 100);
+            SUFFIX_ADD(ptile, json_real(timer_query(&t->tm, config->quantiles[i])));
+        }
+        SUFFIX_ADD(".rate", json_real(timer_sum(&t->tm) / config->flush_interval));
+        SUFFIX_ADD(".sample_rate", json_real((double)timer_count(&t->tm) / config->flush_interval));
+
+        /* Manual histogram bins */
+        if (t->conf) {
+            char ptile[20];
+            sprintf(ptile, ".bin_<%0.2f", t->conf->min_val);
+            SUFFIX_ADD(ptile, json_integer(t->counts[0]));
+            for (int i = 0; i < t->conf->num_bins - 2; i++) {
+                sprintf(ptile, ".bin_%0.2f", t->conf->min_val+(t->conf->bin_width*i));
+                SUFFIX_ADD(ptile, json_integer(t->counts[i+1]));
+            }
+            sprintf(ptile, ".bin_>%0.2f", t->conf->max_val);
+            SUFFIX_ADD(ptile, json_integer(t->counts[t->conf->num_bins - 1]));
+        }
+        break;
+    }
+    default:
+        syslog(LOG_ERR, "Unknown metric type: %d", type);
+        break;
+    }
+
+    return 0;
+}
+
+static int serialize_metrics(http_sink* sink, metrics* m, void* data) {
+    json_t* jobject = json_object();
+
+    struct cb_info info = {
+        .jobject = jobject,
+        .config = sink->sink.global_config,
+        .httpconfig = (const sink_config_http*)sink->sink.sink_config
+    };
+    metrics_iter(m, &info, add_metrics);
+
+    /* TODO: Totally temporary */
+    json_dumpf(jobject, stdout, 0);
+    printf("\n");
+    fflush(stdout);
+    json_decref(jobject);
+    return 0;
+}
+
+sink* init_http_sink(const sink_config_http* sc, const statsite_config* config) {
+    http_sink* s = calloc(1, sizeof(http_sink));
+    s->sink.sink_config = (const sink_config*)sc;
+    s->sink.global_config = config;
+    s->sink.command = (int (*)(sink*, metrics*, void*))serialize_metrics;
+    return (sink*)s;
+}

--- a/src/sink_http.c
+++ b/src/sink_http.c
@@ -305,7 +305,7 @@ static void* http_worker(void* arg) {
     }
 exit:
     free(error_buffer);
-
+    strbuf_free(recv_buf, true);
     return NULL;
 }
 

--- a/src/statsite.c
+++ b/src/statsite.c
@@ -16,6 +16,7 @@
 #include <syslog.h>
 #include <unistd.h>
 #include <signal.h>
+#include <curl/curl.h>
 #include "config.h"
 #include "conn_handler.h"
 #include "networking.h"
@@ -172,6 +173,9 @@ int main(int argc, char **argv) {
     // Set the syslog mask
     setlogmask(config->syslog_log_level);
 
+    // Initialize libcurl
+    curl_global_init(CURL_GLOBAL_DEFAULT);
+
     // Daemonize
     if (config->daemonize) {
         pid_t pid, sid;
@@ -250,6 +254,9 @@ int main(int argc, char **argv) {
 
     // Free our memory
     free_config(config);
+
+    // Tear down libcurl
+    curl_global_cleanup();
 
     // Done
     return 0;

--- a/src/strbuf.c
+++ b/src/strbuf.c
@@ -1,0 +1,79 @@
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include "strbuf.h"
+
+#define GROWTH_FACTOR 1.3
+#define MINIMUM_GROWTH 128
+
+struct strbuf {
+    char* d; /* The main data pointer */
+    size_t size; /* The size of the buffer */
+    int len;  /* The strlen() of the buffer */
+};
+
+void expand(strbuf* buf, size_t new_size) {
+    if (new_size == 0)
+        new_size = buf->size * GROWTH_FACTOR;
+    else
+        new_size += buf->size;
+
+    if (new_size <= buf->size)
+        new_size += MINIMUM_GROWTH;
+
+    buf->d = realloc(buf->d, new_size);
+    buf->size = new_size;
+}
+
+int strbuf_new(strbuf** buf, size_t initial_size) {
+    *buf = malloc(sizeof(strbuf));
+    if (initial_size == 0)
+        initial_size = MINIMUM_GROWTH;
+
+    (*buf)->size = initial_size;
+    (*buf)->len = 0;
+    (*buf)->d = malloc(initial_size);
+    *(*buf)->d = '\0';
+    return 0;
+}
+
+void strbuf_free(strbuf* buf, bool data_too) {
+    if (data_too)
+        free(buf->d);
+    free(buf);
+}
+
+char* strbuf_get(strbuf* buf, int* len) {
+    *len = buf->len;
+    return buf->d;
+}
+
+int strbuf_catsprintf(strbuf* buf, const char* fmt, ...) {
+    va_list args;
+
+    while(true) {
+        size_t available = buf->size - buf->len - 1;
+        va_start(args, fmt);
+        size_t printed = vsnprintf(&(buf->d[buf->len]), available, fmt, args);
+        va_end(args);
+
+        if (printed < available) {
+            buf->len += printed;
+            return buf->len;
+        }
+
+        expand(buf, printed + 1);
+    }
+
+
+    return 0;
+}
+
+int strbuf_cat(strbuf* buf, const char* inp, int len) {
+    if (len + buf->len >= buf->size)
+        expand(buf, len + 1);
+    memcpy(&buf->d[buf->len], inp, len);
+    buf->len += len;
+    buf->d[buf->len] = '\0';
+    return buf->len;
+}

--- a/src/strbuf.c
+++ b/src/strbuf.c
@@ -43,6 +43,10 @@ void strbuf_free(strbuf* buf, bool data_too) {
     free(buf);
 }
 
+void strbuf_truncate(strbuf* buf) {
+    buf->len = 0;
+}
+
 char* strbuf_get(strbuf* buf, int* len) {
     *len = buf->len;
     return buf->d;

--- a/src/strbuf.c
+++ b/src/strbuf.c
@@ -61,11 +61,8 @@ int strbuf_catsprintf(strbuf* buf, const char* fmt, ...) {
             buf->len += printed;
             return buf->len;
         }
-
         expand(buf, printed + 1);
     }
-
-
     return 0;
 }
 

--- a/src/strbuf.h
+++ b/src/strbuf.h
@@ -20,6 +20,11 @@ extern int strbuf_new(strbuf** buf, size_t initial_size);
 extern void strbuf_free(strbuf* buf, bool data_too);
 
 /**
+ * Truncate a buffer by setting its recorded data length to 0
+ */
+extern void strbuf_truncate(strbuf* buf);
+
+/**
  * Returns the underlying character buffer and the current strlen() value
  * of the buffer.
  */

--- a/src/strbuf.h
+++ b/src/strbuf.h
@@ -1,0 +1,39 @@
+#ifndef _STRBUF_H_
+#define _STRBUF_H_
+
+#include <stdarg.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+typedef struct strbuf strbuf;
+
+/**
+ * Allocate a new growable string buffer. The underlying buffer is also
+ * contiguous, so may involve copies on resize.
+ */
+extern int strbuf_new(strbuf** buf, size_t initial_size);
+
+/**
+ * Free a growable buffer. If data_too is set to true, the undelrying
+ * character buffer is also freed.
+ */
+extern void strbuf_free(strbuf* buf, bool data_too);
+
+/**
+ * Returns the underlying character buffer and the current strlen() value
+ * of the buffer.
+ */
+extern char* strbuf_get(strbuf* buf, int* len);
+
+/**
+ * Append a sprintf value into the buffer.
+ */
+extern int strbuf_catsprintf(strbuf* buf, const char* fmt, ...);
+
+/**
+ * Concatenate the given string with the given length,
+ * which is more efficient than calling catsprintf
+ */
+extern int strbuf_cat(strbuf* buf, const char* inp, int len);
+
+#endif

--- a/src/test_strbuf.c
+++ b/src/test_strbuf.c
@@ -1,0 +1,62 @@
+#include <check.h>
+#include <stdio.h>
+#include "strbuf.h"
+
+START_TEST(test_strbuf_new)
+{
+    strbuf* buf;
+    strbuf_new(&buf, 0);
+    fail_unless(buf != NULL);
+    int len;
+    char* d = strbuf_get(buf, &len);
+    fail_unless(d != NULL);
+    fail_unless(len == 0);
+    strbuf_free(buf, true);
+}
+END_TEST
+
+START_TEST(test_strbuf_printf)
+{
+    strbuf* buf;
+    strbuf_new(&buf, 0);
+    fail_unless(buf != NULL);
+    int len;
+    char* d = strbuf_get(buf, &len);
+    fail_unless(d != NULL);
+    fail_unless(len == 0);
+
+    strbuf_catsprintf(buf, "hello world %s", "hello world");
+    strbuf_catsprintf(buf, "hi");
+    strbuf_cat(buf, "hu", 2);
+    d = strbuf_get(buf, &len);
+    fail_unless(d != NULL);
+    fail_unless(len == 11 + 1 + 11 + 2 + 2);
+
+    ck_assert_str_eq(d, "hello world hello worldhihu");
+
+    strbuf_free(buf, true);
+}
+END_TEST
+
+START_TEST(test_strbuf_big)
+{
+    strbuf* buf;
+    strbuf_new(&buf, 0);
+    fail_unless(buf != NULL);
+    int len;
+    char* d = strbuf_get(buf, &len);
+    fail_unless(d != NULL);
+    fail_unless(len == 0);
+
+    for (int i = 0; i < 1000; i++)
+        strbuf_catsprintf(buf, "hello world");
+
+    d = strbuf_get(buf, &len);
+    fail_unless(d != NULL);
+    fail_unless(len == 1000 * 11);
+
+    fail_unless(strncmp(d, "hello worldhello world", 22) == 0);
+
+    strbuf_free(buf, true);
+}
+END_TEST

--- a/statsite.spec
+++ b/statsite.spec
@@ -2,7 +2,7 @@
 
 Name:		statsite
 Version:	0.7.2
-Release:	3%{?dist}
+Release:	4%{?dist}
 Summary:	A C implementation of statsd.
 Group:		Applications
 License:	See the LICENSE file.

--- a/statsite.spec
+++ b/statsite.spec
@@ -1,8 +1,8 @@
 %global __os_install_post %(echo '%{__os_install_post}' | sed -e 's!/usr/lib[^[:space:]]*/brp-python-bytecompile[[:space:]].*$!!g')
 
 Name:		statsite
-Version:	0.7.1
-Release:	2%{?dist}
+Version:	0.7.2
+Release:	1%{?dist}
 Summary:	A C implementation of statsd.
 Group:		Applications
 License:	See the LICENSE file.

--- a/statsite.spec
+++ b/statsite.spec
@@ -2,15 +2,15 @@
 
 Name:		statsite
 Version:	0.7.2
-Release:	4%{?dist}
+Release:	6%{?dist}
 Summary:	A C implementation of statsd.
 Group:		Applications
 License:	See the LICENSE file.
 URL:		https://github.com/twitter-forks/statsite
 Source0:	statsite.tar.gz
-Requires:       %{!?el5:libcurl} %{?el5:curl} jansson
+Requires:       %{!?el5:libcurl-openssl} %{?el5:curl} jansson
 BuildRoot:	%(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
-BuildRequires:	scons check-devel %{?el7:systemd} %{?fedora:systemd} %{?el5:curl-devel} %{!?el5:libcurl-devel} jansson-devel
+BuildRequires:	scons check-devel %{?el7:systemd} %{?fedora:systemd} %{?el5:curl-devel} %{!?el5:libcurl-openssl-devel} %{!?el5:libcurl-devel}  jansson-devel
 AutoReqProv:	No
 Requires(pre):  /usr/sbin/useradd, /usr/bin/getent
 
@@ -23,7 +23,7 @@ https://github.com/etsy/statsd, and is wire compatible.
 %setup -c %{name}-%{version}
 
 %build
-make %{?_smp_mflags}
+CURL_LIB=curl-openssl scons %{?_smp_mflags}
 
 %install
 mkdir -vp $RPM_BUILD_ROOT/usr/sbin
@@ -127,6 +127,9 @@ exit 0
 %attr(755, root, root) /usr/libexec/statsite/sinks/opentsdb.js
 
 %changelog
+* Tue Jun 16 2015 Yann Ramin - 0.7.2-6
+- Allow builds using alternate libcurl
+
 * Fri Jun 05 2015 Yann Ramin - 0.7.1-2
 - Fix user creation in statsite
 

--- a/statsite.spec
+++ b/statsite.spec
@@ -2,7 +2,7 @@
 
 Name:		statsite
 Version:	0.7.2
-Release:	1%{?dist}
+Release:	2%{?dist}
 Summary:	A C implementation of statsd.
 Group:		Applications
 License:	See the LICENSE file.

--- a/statsite.spec
+++ b/statsite.spec
@@ -2,7 +2,7 @@
 
 Name:		statsite
 Version:	0.7.2
-Release:	2%{?dist}
+Release:	3%{?dist}
 Summary:	A C implementation of statsd.
 Group:		Applications
 License:	See the LICENSE file.

--- a/tests/runner.c
+++ b/tests/runner.c
@@ -13,6 +13,7 @@
 #include "test_hll.c"
 #include "test_set.c"
 #include "test_lifoq.c"
+#include "test_strbuf.c"
 
 int main(void)
 {
@@ -31,6 +32,7 @@ int main(void)
     TCase *tc10 = tcase_create("hyperloglog");
     TCase *tc11 = tcase_create("set");
     TCase *tc12 = tcase_create("lifoq");
+    TCase *tc13 = tcase_create("strbuf");
     SRunner *sr = srunner_create(s1);
     int nf;
 
@@ -125,7 +127,7 @@ int main(void)
     tcase_add_test(tc8, test_sane_quantiles);
     tcase_add_test(tc8, test_basic_sink);
     tcase_add_test(tc8, test_multi_sink);
-    
+
     // Add the radix tests
     suite_add_tcase(s1, tc9);
     tcase_add_test(tc9, test_radix_init_and_destroy);
@@ -159,10 +161,16 @@ int main(void)
     tcase_add_test(tc12, test_lifoq_overflow);
     tcase_add_test(tc12, test_lifoq_close);
 
+    // Add the strbuf tests
+    suite_add_tcase(s1, tc13);
+    tcase_add_test(tc13, test_strbuf_new);
+    tcase_add_test(tc13, test_strbuf_printf);
+    tcase_add_test(tc13, test_strbuf_big);
+
+
     srunner_run_all(sr, CK_ENV);
     nf = srunner_ntests_failed(sr);
     srunner_free(sr);
 
     return nf == 0 ? 0 : 1;
 }
-

--- a/tests/test_lifoq.c
+++ b/tests/test_lifoq.c
@@ -17,7 +17,7 @@ START_TEST(test_lifoq_basic)
     *data = 12;
 
     lifoq_new(&q, 10);
-    int ret = lifoq_push(q, data, 1, true);
+    int ret = lifoq_push(q, data, 1, true, false);
     fail_unless(ret == 0);
 
     int* fdata = NULL;
@@ -39,12 +39,12 @@ START_TEST(test_lifoq_overflow)
     *data = 12;
 
     lifoq_new(&q, 10);
-    int ret = lifoq_push(q, data, 10, true);
+    int ret = lifoq_push(q, data, 10, true, false);
     fail_unless(ret == 0);
 
     int* data2 = malloc(sizeof(int));
     *data2 = 13;
-    ret = lifoq_push(q, data2, 9, true);
+    ret = lifoq_push(q, data2, 9, true, false);
     fail_unless(ret == 0);
     /*
      * At this point, data should have been removed from the queue and the
@@ -60,7 +60,7 @@ START_TEST(test_lifoq_overflow)
     /* Queue should be empty at this state */
     /* Insert a "new" element to confirm it is */
     *data2 = 14;
-    ret = lifoq_push(q, data2, 8, true);
+    ret = lifoq_push(q, data2, 8, true, false);
     fail_unless(ret == 0);
     /* Check that this new element is added */
     ret = lifoq_get(q, (void**)&fdata, &s);
@@ -68,6 +68,11 @@ START_TEST(test_lifoq_overflow)
     fail_unless(*fdata == 14);
     fail_unless(s == 8);
 
+    /* Do a push with failure */
+    ret = lifoq_push(q, data2, 8, true, true);
+    fail_unless(ret == 0);
+    ret = lifoq_push(q, data2, 8, true, true);
+    fail_unless(ret == LIFOQ_FULL);
 
     free(data2);
     free(q);
@@ -81,7 +86,7 @@ START_TEST(test_lifoq_close)
     *data = 12;
 
     lifoq_new(&q, 10);
-    int ret = lifoq_push(q, data, 10, true);
+    int ret = lifoq_push(q, data, 10, true, false);
     fail_unless(ret == 0);
 
     ret = lifoq_close(q);
@@ -89,7 +94,7 @@ START_TEST(test_lifoq_close)
 
     int* data2 = malloc(sizeof(int));
     *data2 = 13;
-    ret = lifoq_push(q, data2, 9, true);
+    ret = lifoq_push(q, data2, 9, true, false);
     fail_unless(ret == LIFOQ_CLOSED);
 
     int* fdata = NULL;


### PR DESCRIPTION
In order to reduce pull request size and interdependence,
here is an incremental step for a stdout JSON output sink. The stdout
writes will of course be replaced with a lifoq push for libcurl posting.

The current sink infrastructure is a bit hard to unit test - once the
HTTP plumbing is in place, there is an integration test for it.
