### PR TITLE
Convert a quantile to a percentile integer, such as: 0.50 -> 50, 0.99 -> 99, 0.999 -> 999

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -60,6 +60,7 @@ objs = env_statsite_with_err.Object('src/hashmap', 'src/hashmap.c')           + 
         env_statsite_with_err.Object('src/sink_stream', 'src/sink_stream.c')  + \
         env_statsite_with_err.Object('src/lifoq', 'src/lifoq.c')              + \
         env_statsite_with_err.Object('src/sink_http', 'src/sink_http.c')      + \
+        env_statsite_with_err.Object('src/utils', 'src/utils.c')                + \
         env_statsite_libev.Object('src/networking', 'src/networking.c')       + \
         env_statsite_libev.Object('src/conn_handler', 'src/conn_handler.c')
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -1,0 +1,19 @@
+#include "utils.h"
+
+int to_percentile(double quantile, int *percentile) {
+    if (quantile < 0 || quantile > 1) {
+        return -1;
+    }
+
+    /* Make sure the percentile has at least two digits */
+    quantile *= 100;
+
+    /*
+     * Shift the double and get rid of the trailing 0s
+     */
+    while (quantile != (int)quantile) {
+        quantile *= 10;
+    }
+    *percentile = (int) quantile;
+    return 0;
+}

--- a/src/utils.h
+++ b/src/utils.h
@@ -1,0 +1,12 @@
+#ifndef _UTILS_H_
+#define _UTILS_H_
+
+/**
+ * Convert a quantile to a percentil integer, such as: 0.50 -> 50, 0.99 -> 99, 0.999 -> 999
+ * @arg quantile
+ * @arg percentile Output.
+ * @return 0 on success, negative on error.
+ */
+extern int to_percentile(double quantile, int *percentile);
+
+#endif

--- a/tests/runner.c
+++ b/tests/runner.c
@@ -14,6 +14,7 @@
 #include "test_set.c"
 #include "test_lifoq.c"
 #include "test_strbuf.c"
+#include "test_utils.c"
 
 int main(void)
 {
@@ -33,6 +34,7 @@ int main(void)
     TCase *tc11 = tcase_create("set");
     TCase *tc12 = tcase_create("lifoq");
     TCase *tc13 = tcase_create("strbuf");
+    TCase *tc14 = tcase_create("utils");
     SRunner *sr = srunner_create(s1);
     int nf;
 
@@ -167,6 +169,9 @@ int main(void)
     tcase_add_test(tc13, test_strbuf_printf);
     tcase_add_test(tc13, test_strbuf_big);
 
+    // Add the utils tests
+    suite_add_tcase(s1, tc14);
+    tcase_add_test(tc14, test_percentile_convertion);
 
     srunner_run_all(sr, CK_ENV);
     nf = srunner_ntests_failed(sr);

--- a/tests/test_utils.c
+++ b/tests/test_utils.c
@@ -1,0 +1,30 @@
+#include <check.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <fcntl.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <errno.h>
+
+#include "utils.h"
+
+START_TEST(test_percentile_convertion)
+{
+    int percentile;
+    fail_unless(to_percentile(-0.1, &percentile) != 0);
+    fail_unless(to_percentile(1.1, &percentile) != 0);
+
+    fail_unless(to_percentile(0, &percentile) == 0);
+    fail_unless(percentile == 0);
+
+    fail_unless(to_percentile(1.00, &percentile) == 0);
+    fail_unless(percentile == 100);
+
+    fail_unless(to_percentile(0.5, &percentile) == 0);
+    fail_unless(percentile == 50);
+
+    fail_unless(to_percentile(0.999900, &percentile) == 0);
+    fail_unless(percentile == 9999);
+}
+END_TEST


### PR DESCRIPTION
Fix the problem that http/stream sinks can not output percentile with precision more than P99
