### PR TITLE
Sample Twitter Statsite config for use with external cuckoo-relay end…

### DIFF
--- a/twitter-monitoring-relay.conf
+++ b/twitter-monitoring-relay.conf
@@ -7,7 +7,7 @@ udp_port = 8125
 log_level = INFO
 log_facility = local0
 flush_interval = 10
-timer_eps = 0.01
+timer_eps = 0.001
 set_eps = 0.02
 
 ; If a customer is dual writing metrics to both Twitter Observability
@@ -16,9 +16,8 @@ set_eps = 0.02
 [sink_stream_graphite]
 command = python sinks/graphite.py localhost 2003
 
-; Configured to use Twitter Observability https endpoint
-;
-; insert service specific 1) oauth_key and 2) oauth_secret
+; Configured to use Twitter Observability https endpoint:
+; Insert service specific 1) oauth_key and 2) oauth_secret
 ;
 [sink_http_appName]
 url = https://monitoring-relay.twitter.com/cuckoo/v1/trusted/store

--- a/twitter-monitoring-relay.conf
+++ b/twitter-monitoring-relay.conf
@@ -1,0 +1,40 @@
+; Default Twitter statsite config for external Twitter customers
+; that are using Twitter Observability via our https endpoint.
+;
+[statsite]
+port = 8125
+udp_port = 8125
+log_level = INFO
+log_facility = local0
+flush_interval = 10
+timer_eps = 0.01
+set_eps = 0.02
+
+; If a customer is dual writing metrics to both Twitter Observability
+; via https and an existing graphite/carbon instance
+;
+[sink_stream_graphite]
+command = python sinks/graphite.py localhost 2003
+
+; Configured to use Twitter Observability https endpoint
+;
+; insert service specific 1) oauth_key and 2) oauth_secret
+;
+[sink_http_appName]
+url = https://monitoring-relay.twitter.com/cuckoo/v1/trusted/store
+oauth_key = test_key
+oauth_secret = test_secret
+oauth_token_url = https://api.twitter.com/oauth2/token 
+
+[histogram_api]
+prefix=api
+min=0
+max=100
+width=5
+
+[histogram_default]
+prefix=
+min=0
+max=200
+width=20
+


### PR DESCRIPTION
Introducing a default Twitter Statsite config for customers using Twitter's Observability stack
