### PR TITLE
Add use_prefix flag to http sinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,8 @@ Here is an example configuration file for Twitter Observability::
     url = https://monitoring-relay.twitter.com/cuckoo/v1/trusted/store
     oauth_key = test_key
     oauth_secret = test_secret
-    oauth_token_url = https://api.twitter.com/oauth2/token 
+    oauth_token_url = https://api.twitter.com/oauth2/token
+    use_prefix = true
     
     [histogram_api]
     prefix=api
@@ -290,6 +291,7 @@ HTTP sinks take the following options:
 * url : The URL of posting the metrics
 * oauth_key & oauth_secret : The OAuth identity and credential information 
 * oauth_token_url : The URL of authenticating the application of exchange the OAuth credentials for a bearer token
+* use_prefix : Whether to add global_prefix and type-specific prefixes (e.g. kv_prefix)
 
 ### Histograms
 

--- a/src/config.c
+++ b/src/config.c
@@ -89,7 +89,8 @@ static const sink_config_http DEFAULT_HTTP_SINK = {
     .ciphers = NULL,
     .oauth_key = NULL,
     .oauth_secret = NULL,
-    .oauth_token_url = NULL
+    .oauth_token_url = NULL,
+    .use_prefix = true
 };
 
 /**
@@ -316,6 +317,8 @@ static int sink_callback(void* user, const char* section, const char* name, cons
             config->oauth_secret = strdup(value);
         } else if (NAME_MATCH("oauth_token_url")) {
             config->oauth_token_url = strdup(value);
+        } else if (NAME_MATCH("use_prefix")) {
+            value_to_bool(value, &config->use_prefix);
         } else {
             /* Attempt to locate keys
              * of the form param_PNAME */

--- a/src/config.h
+++ b/src/config.h
@@ -68,6 +68,7 @@ typedef struct sink_config_http {
     const char* oauth_key; /* OAuth2 Consumer Key */
     const char* oauth_secret; /* OAuth2 Secret */
     const char* oauth_token_url; /* URL to get a new token from */
+    bool use_prefix; /* Whether to prefix metric keys */
 } sink_config_http;
 
 // Represents the configuration of a histogram


### PR DESCRIPTION
This pull adds a flag to http sinks to disable prefixing of metrics.

Use case: In moving from a statsite/graphite setup to a statsite/graphite/Twitter Observability setup, we're configuring statsite to output both to the Twitter Observability http_sink as well as the Graphite command_sink. Our existing Graphite metrics use the default prefixes for metrics ('gauges', 'timers', etc) but we don't want these prefixes added to metrics stored in Twitter Observability as they wont be added by Absorber when we move into the Twitter DC and dont match Twitter conventions.

Solution: Add a flag similar to prefix_binary_stream as an http_sink config: use_prefix.  Setting this flag to true (default: false) will cause all prefixes to be ignored for the http_sink in question
