### PR TITLE
Require subunit for tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ADD . /statsite
 
 RUN mkdir -p /statsite && mkdir -p /var/run/statsite && \
     apt-get update && \
-    apt-get install -y build-essential check scons libjansson-dev libcurl4-openssl-dev libcurl3 libjansson4 && \
+    apt-get install -y build-essential check scons libjansson-dev libcurl4-openssl-dev libjansson4 && \
     (cd statsite && make) && \
     apt-get purge -y build-essential check scons libcurl4-openssl-dev libjansson-dev && \
     apt-get autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/SConstruct
+++ b/SConstruct
@@ -74,7 +74,7 @@ if platform.system() == 'Linux':
    statsite_libs.append("rt")
 
 statsite = env_statsite_with_err.Program('statsite', objs + ["src/statsite.c"], LIBS=statsite_libs)
-statsite_test = env_statsite_without_err.Program('test_runner', objs + Glob("tests/runner.c"), LIBS=statsite_libs + ["check"])
+statsite_test = env_statsite_without_err.Program('test_runner', objs + Glob("tests/runner.c"), LIBS=statsite_libs + ["check", "subunit"])
 
 # By default, only compile statsite
 Default(statsite)


### PR DESCRIPTION
libcheck now explicitly requires linking of libsubunit for subunit output

Also fix Dockerfile to not require two conflicting versions of libcurl