### PR TITLE
Update default cipher suites to current Twitter standards

### DIFF
--- a/src/sink_http.c
+++ b/src/sink_http.c
@@ -17,8 +17,12 @@
 const useconds_t FAILURE_WAIT = 5000000; /* 5 seconds */
 const int INITIAL_EXTRA_POST_BUFFER_SIZE = 128;
 
-const char* DEFAULT_CIPHERS_NSS = "ecdhe_ecdsa_aes_128_gcm_sha_256,ecdhe_rsa_aes_256_sha,rsa_aes_128_gcm_sha_256,rsa_aes_256_sha,rsa_aes_128_sha";
-const char* DEFAULT_CIPHERS_OPENSSL = "EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH:DHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA";
+/* Twitter official recommended "Modern" cipher suite
+ * Updated: 2019-09-20
+ * go/ciphers
+ */
+const char* DEFAULT_CIPHERS_NSS = "ecdhe_ecdsa_aes_256_gcm_sha_384:ecdhe_rsa_aes_256_gcm_sha_384:ecdhe_ecdsa_aes_128_gcm_sha_256:ecdhe_rsa_aes_128_gcm_sha_256:ecdhe_ecdsa_aes_256_sha_384:ecdhe_rsa_aes_256_sha_384:ecdhe_ecdsa_aes_128_sha:ecdhe_rsa_aes_128_sha:aes_256_gcm_sha_384:aes_128_gcm_sha_256";
+const char* DEFAULT_CIPHERS_OPENSSL = "ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:AES256-GCM-SHA384:AES128-GCM-SHA256:AES256-SHA256:AES128-SHA256";
 
 const char* USERAGENT = "statsite-http/0";
 const char* OAUTH2_GRANT = "grant_type=client_credentials";


### PR DESCRIPTION
Update default cipher list to the current Twitter standard (based on https://wiki.mozilla.org/Security/Server_Side_TLS)